### PR TITLE
Fixed use of Unicode event struct with regestering for ANSI ones (not Unicode)

### DIFF
--- a/src/media_foundation/media_foundation_camera_notifications.cpp
+++ b/src/media_foundation/media_foundation_camera_notifications.cpp
@@ -91,12 +91,11 @@ namespace webcam_capture {
         //create stream to move to new stream
         windowClass = {};
         windowClass.lpfnWndProc = &MediaFoundation_CameraNotifications::WindowProcedure;
-        //LPCWSTR windowClassName = L"CameraNotificationsMessageOnlyWindow";
 
         LPCSTR windowClassName = "CameraNotificationsMessageOnlyWindow";
         windowClass.lpszClassName = windowClassName;
 
-        if (!RegisterClassA(&windowClass)) {
+        if (!RegisterClass(&windowClass)) {
             DEBUG_PRINT("Failed to register window class.\n");
             return;
         }
@@ -116,7 +115,7 @@ namespace webcam_capture {
         NotificationFilter.dbcc_classguid  = KSCATEGORY_VIDEO;
 
 
-        hDevNotify = RegisterDeviceNotification(messageWindow, &NotificationFilter, DEVICE_NOTIFY_WINDOW_HANDLE);
+        hDevNotify = RegisterDeviceNotificationW(messageWindow, &NotificationFilter, DEVICE_NOTIFY_WINDOW_HANDLE);
 
         MSG msg;
         GetMessage(&msg, messageWindow, 0, 0);

--- a/src/media_foundation/media_foundation_camera_notifications.h
+++ b/src/media_foundation/media_foundation_camera_notifications.h
@@ -31,7 +31,7 @@ namespace webcam_capture {
         MediaFoundation_Backend * backend;
         std::vector<CameraInformation*> devicesVector;
         HDEVNOTIFY hDevNotify;
-        WNDCLASSA windowClass;
+        WNDCLASS windowClass;
         HWND messageWindow;
 
         bool stopMessageThread;


### PR DESCRIPTION
Ты кастуешь структуру в `DEV_BROADCAST_DEVICEINTERFACE_W`, т.е. в Unicode версию, когда ты не используешь Unicode версию `RegisterDeviceNotification`. По умолчанию `RegisterDeviceNotification` это `RegisterDeviceNotificationA`, а `RegisterDeviceNotificationA` будет давать тебе `DEV_BROADCAST_DEVICEINTERFACE_A` структуру, не `DEV_BROADCAST_DEVICEINTERFACE_W`. Чтобы получить `DEV_BROADCAST_DEVICEINTERFACE_W` надо `RegisterDeviceNotificationW` использовать.

Так же изменил
`RegisterClassA` --> `RegisterClass`
`WNDCLASSA` --> `WNDCLASS`
т.к. по умолчанию и так используются ANSI версии.
