### PR TITLE
Added ability to make a shared build of the library

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -30,6 +30,7 @@ Name | Description | Default
 |BACKEND_MEDIA_FOUNDATION | Build with Media Foundation backend support. | OFF
 |WINDOWS_TARGET_OS | Target OS: WindowsXP, WindowsVista, Windows7 or Windows8. | "NONE"
 |WINDOWS_TARGET_ARCH | Target architecture: x86, x64 or ARM. ARM is available for WINDOWS_TARGET_OS=Windows8 only. | "NONE"
+|BUILD_STATIC | Build the library as a static library. | OFF
 |TEST_APP | Build the test application. | OFF
 |TEST_APP_WINDOWS_QT5_PATH | Path to Qt5 directory in which bin, lib and include subdirs reside. | "NONE"
 |CMAKE_BUILD_TYPE | Build type of the produced binaries: Release or Debug. | "Release"
@@ -41,7 +42,7 @@ Note that options are cached in CMakeCache.txt.
 
 #####Build Instructions
 
-We will show you how to build a 64-bit static version of the library, together with the test application, targeting Windows 8 system. You can easily adjust these instructions for anything you'd like.
+We will show you how to build a 64-bit shared version of the library, together with the test application, targeting Windows 8 system. You can easily adjust these instructions for anything you'd like.
 
 Start `cmd.exe` and navigate the the root directory of the project in it.
 
@@ -75,7 +76,7 @@ set LIB=%ProgramFiles(x86)%\Microsoft SDKs\Windows\v7.1A\Lib\x64;%LIB%
 
 Now that the compiler-related enviroment variables are set up, we can call CMake.
 ```cmd
-cmake -G"NMake Makefiles" -DCMAKE_BUILD_TYPE="Release" -DWINDOWS_TARGET_OS="Windows8" -DWINDOWS_TARGET_ARCH="x64" -DBACKEND_MEDIA_FOUNDATION=ON -DTEST_APP=ON -DTEST_APP_WINDOWS_QT5_PATH="C:/Qt/5.4/msvc2013_64_opengl" -DCMAKE_INSTALL_PREFIX:PATH=prefix ..
+cmake -G"NMake Makefiles" -DCMAKE_BUILD_TYPE="Release" -DBUILD_STATIC=OFF -DWINDOWS_TARGET_OS="Windows8" -DWINDOWS_TARGET_ARCH="x64" -DBACKEND_MEDIA_FOUNDATION=ON -DTEST_APP=ON -DTEST_APP_WINDOWS_QT5_PATH="C:/Qt/5.4/msvc2013_64_opengl" -DCMAKE_INSTALL_PREFIX:PATH=prefix ..
 ```
 
 Read the output of the cmake command to see if there are any errors or warnings, even if the command exited successfully, and check that its output doesn't contradict with the options you set (i.e. you set "Release" build type, but cmake printed out "Debug"). Fix any issue there is. You might want to delete the `CMakeCache.txt` file for new option to work, if you are re-running cmake with different options.

--- a/include/backend_factory.h
+++ b/include/backend_factory.h
@@ -1,14 +1,16 @@
 #ifndef BACKEND_FACTORY
 #define BACKEND_FACTORY
-#include <backend_interface.h>
+
 #include <backend_implementation.h>
+#include <backend_interface.h>
+#include <webcam_capture_export.h>
 
 namespace webcam_capture {
 
     /**
      *  The class representing the factory for BackendInterface entities creating.
      */
-    class BackendFactory {
+    class WEBCAM_CAPTURE_EXPORT BackendFactory {
     public:
         /**
          * @param Specifies a backend you want to use

--- a/include/backend_implementation.h
+++ b/include/backend_implementation.h
@@ -1,12 +1,14 @@
 #ifndef BACKEND_IMPLEMENTATION_H
 #define BACKEND_IMPLEMENTATION_H
 
+#include <webcam_capture_export.h>
+
 namespace webcam_capture  {
 
     /**
      * Enum of supported video capture frameworks
      */
-    enum class BackendImplementation {MediaFoundation, v4l, AVFoundation};  //TODO to fix v4l name. (maybe it using v4l2???)
+    enum class WEBCAM_CAPTURE_EXPORT BackendImplementation {MediaFoundation, v4l, AVFoundation};  //TODO to fix v4l name. (maybe it using v4l2???)
 
 } // namespace webcam_capture
 

--- a/include/backend_interface.h
+++ b/include/backend_interface.h
@@ -7,17 +7,18 @@
 #ifndef BACKEND_INTERFACE_H
 #define BACKEND_INTERFACE_H
 
+#include <functional>
 #include <stdio.h>
 #include <string>
 #include <vector>
-#include <functional>
 
-#include <camera_interface.h>
 #include <camera_information.h>
+#include <camera_interface.h>
+#include <webcam_capture_export.h>
 
 namespace webcam_capture {
 
-    enum class CameraPlugStatus {
+    enum class WEBCAM_CAPTURE_EXPORT CameraPlugStatus {
         CAMERA_CONNECTED,
         CAMERA_DISCONNECTED
     };
@@ -30,7 +31,7 @@ namespace webcam_capture {
     /**
      * Contains Interface for Backend realization
      */
-    class BackendInterface {
+    class WEBCAM_CAPTURE_EXPORT BackendInterface {
     public:
         BackendInterface() {}
         virtual ~BackendInterface() {}

--- a/include/camera_information.h
+++ b/include/camera_information.h
@@ -6,15 +6,18 @@
 
 #ifndef CAMERA_INFORMATION_H
 #define CAMERA_INFORMATION_H
+
 #include <string.h>
+
 #include <unique_id.h>
+#include <webcam_capture_export.h>
 
 namespace webcam_capture {
 
     /**
      * Contains informationa about single camera
      */
-    class CameraInformation {
+    class WEBCAM_CAPTURE_EXPORT CameraInformation {
     public:
        /**
        * @param cameraId Camera Id

--- a/include/camera_interface.h
+++ b/include/camera_interface.h
@@ -8,14 +8,15 @@
 #define CAMERA_INTERFACE_H
 
 #include <functional>
-#include <vector>
 #include <memory>
+#include <vector>
 
+#include <camera_information.h>
 #include <capability.h>
 #include <pixel_buffer.h>
-#include <camera_information.h>
-#include <video_property_range.h>
 #include <video_property.h>
+#include <video_property_range.h>
+#include <webcam_capture_export.h>
 
 namespace webcam_capture {
     /**
@@ -26,7 +27,7 @@ namespace webcam_capture {
     /**
      * Contains Interface for Camera realization
      */
-    class CameraInterface {
+    class WEBCAM_CAPTURE_EXPORT CameraInterface {
     public:
         CameraInterface() {}
         virtual ~CameraInterface() {}

--- a/include/capability.h
+++ b/include/capability.h
@@ -8,7 +8,9 @@
 #define CAPABILITY_H
 
 #include <vector>
+
 #include <format.h>
+#include <webcam_capture_export.h>
 
 namespace webcam_capture  {
 
@@ -19,7 +21,7 @@ namespace webcam_capture  {
     /**
     * Contains valid values of a FPS
     */
-    class CapabilityFps {
+    class WEBCAM_CAPTURE_EXPORT CapabilityFps {
     public:
         ~CapabilityFps() {}
 
@@ -50,7 +52,7 @@ namespace webcam_capture  {
     /**
     * Contains valid values of a width, height and fpses vector
     */
-    class CapabilityResolution {
+    class WEBCAM_CAPTURE_EXPORT CapabilityResolution {
     public:
         ~CapabilityResolution() {}
 
@@ -102,7 +104,7 @@ namespace webcam_capture  {
     /**
     * Contains valid values of a PixelFormat and Resolutions vector
     */
-    class CapabilityFormat{
+    class WEBCAM_CAPTURE_EXPORT CapabilityFormat{
     public:
         ~CapabilityFormat() {}
         /**

--- a/include/format.h
+++ b/include/format.h
@@ -12,11 +12,13 @@
 #ifndef FORMAT_H
 #define FORMAT_H
 
+#include <webcam_capture_export.h>
+
 namespace webcam_capture {
     /**
      * Enum of supported video capture formats
      */
-    enum class Format { //Uncompressed RGB Formats
+    enum class WEBCAM_CAPTURE_EXPORT Format { //Uncompressed RGB Formats
                         RGB8,           /* RGB, 8 bits per pixel (bpp)*/
                         RGB555,         /* RGB 555, 16 bpp*/
                         RGB565,         /* RGB 565, 16 bpp*/

--- a/include/image_format_converter.h
+++ b/include/image_format_converter.h
@@ -1,13 +1,15 @@
 #ifndef IMAGE_FORMAT_CONVERTER
 #define IMAGE_FORMAT_CONVERTER
+
 #include <pixel_buffer.h>
+#include <webcam_capture_export.h>
 
 namespace webcam_capture {
 
     /**
      * @brief Class of frames converting
      */
-    class ImageFormatConverter{
+    class WEBCAM_CAPTURE_EXPORT ImageFormatConverter{
     public:
         /**
          * @param ConvertToRGB input frame

--- a/include/pixel_buffer.h
+++ b/include/pixel_buffer.h
@@ -6,8 +6,11 @@
 
 #ifndef PIXEL_BUFFER_H
 #define PIXEL_BUFFER_H
-#include <format.h>
+
 #include <stdint.h>
+
+#include <format.h>
+#include <webcam_capture_export.h>
 
 namespace webcam_capture  {
     /**

--- a/include/unique_id.h
+++ b/include/unique_id.h
@@ -1,10 +1,12 @@
 #ifndef UNIQUE_ID
 #define UNIQUE_ID
+
 #include <backend_implementation.h>
+#include <webcam_capture_export.h>
 
 namespace webcam_capture {
 
-    class UniqueId {
+    class WEBCAM_CAPTURE_EXPORT UniqueId {
     public:
         UniqueId(BackendImplementation implementation);
         virtual ~UniqueId();

--- a/include/video_property.h
+++ b/include/video_property.h
@@ -1,11 +1,13 @@
 #ifndef VIDEOPROPERTY_H
 #define VIDEOPROPERTY_H
 
+#include <webcam_capture_export.h>
+
 namespace webcam_capture  {
     /**
      *  Enum of supported capabilities
      */
-    enum class VideoProperty { Brightness, Contrast, Saturation};
+    enum class WEBCAM_CAPTURE_EXPORT VideoProperty { Brightness, Contrast, Saturation};
 
 } // namespace webcam_capture
 

--- a/include/video_property_range.h
+++ b/include/video_property_range.h
@@ -1,11 +1,13 @@
 #ifndef VIDEO_PROPERTY_RANGE_H
 #define VIDEO_PROPERTY_RANGE_H
 
+#include <webcam_capture_export.h>
+
 namespace webcam_capture {
     /**
      *  Contains valid values of a VideoProperty
      */
-    class VideoPropertyRange {
+    class WEBCAM_CAPTURE_EXPORT VideoPropertyRange {
         public:
             VideoPropertyRange():
                 minValue(0),

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,6 +5,15 @@ if (${CMAKE_BUILD_TYPE} STREQUAL "Debug")
   add_definitions(-DWEBCAM_CAPTURE_DEBUG)
 endif()
 
+option(BUILD_STATIC "Build the library as static library" OFF)
+if (BUILD_STATIC)
+  set(LIBRARY_TYPE "STATIC")
+  message(STATUS "Building static library")
+else()
+  set(LIBRARY_TYPE "SHARED")
+  message(STATUS "Building shared library")
+endif()
+
 # backend options
 
 if (WIN32)
@@ -38,6 +47,8 @@ if (NOT LIBS)
   message(FATAL_ERROR "You are building the library with no backends enabled, which doesn't make sense. Please enable at least one backend. Use cmake -LH to get a list of backends.")
 endif()
 
+include (GenerateExportHeader)
+add_compiler_export_flags()
 
 aux_source_directory(. SRC_LIST)
 
@@ -45,11 +56,14 @@ aux_source_directory(. SRC_LIST)
 # also used for installation
 file(GLOB INCLUDE_LIST ${CMAKE_SOURCE_DIR}/include/*.h)
 
-add_library(${TARGET} ${SRC_LIST} ${INCLUDE_LIST} ${BACKEND_SRC_LIST})
+add_library(${TARGET} ${LIBRARY_TYPE} ${SRC_LIST} ${INCLUDE_LIST} ${BACKEND_SRC_LIST})
 target_link_libraries(${TARGET} ${LIBS})
 
+generate_export_header(${TARGET})
+set(INCLUDE_LIST ${INCLUDE_LIST} ${PROJECT_BINARY_DIR}/src/${TARGET}_export.h)
+
 # make public headers globally available
-target_include_directories(${TARGET} PUBLIC ${CMAKE_SOURCE_DIR}/include)
+target_include_directories(${TARGET} PUBLIC ${CMAKE_SOURCE_DIR}/include ${PROJECT_BINARY_DIR}/src)
 
 
 if (WIN32)


### PR DESCRIPTION
Добавил возможность создания динамической библиотеки (dll).

`webcam_capture_export.h` автоматически генерируется CMake'ом (он отличается для статических и динамических сборок).

По умолчанию выставлена динамическая сборка, при которой тебе не удастся запустить test_app из Qt Creator т.к. webcam_capture.dll будет в другой папке и не будет видна. Это можно починить если запросить статическую сборку, которая у нас раньше была по умолчанию, с помощью `-DBUILD_STATIC=ON`.
